### PR TITLE
FO-881: Build and push docker image to dockerhub

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,11 +1,39 @@
 steps:
 - name: 'gcr.io/cloud-builders/docker'
-  args: [
-    'build',
-    '-f', 'Dockerfile',
-    '-t', 'gcr.io/$PROJECT_ID/pubsub-emulator:$COMMIT_SHA',
-    '.'
+  id: 'dockerhub-login'
+  waitFor: ['-']
+  # bash entrypoint is required in order to pass the secret environment variables
+  entrypoint: 'bash'
+  args: ['-c', 'docker login --username=$$DOCKERHUB_USERNAME --password=$$DOCKERHUB_PASSWORD']
+  secretEnv: ['DOCKERHUB_USERNAME', 'DOCKERHUB_PASSWORD']
+
+- name: 'gcr.io/cloud-builders/docker'
+  id: 'deploy-scripts-build'
+  waitFor: ['-']
+  # bash entrypoint is required in order to pass the secret environment variables
+  entrypoint: 'bash'
+  # NOTE: This is tagging twice. This allows us to push to GCR which is our source of truth, and DockerHub for lower cost use in CircleCI
+  args: ['-c', 'docker build --tag $$DOCKERHUB_USERNAME/pubsub-emulator:$COMMIT_SHA --tag gcr.io/$PROJECT_ID/pubsub-emulator:$COMMIT_SHA --file Dockerfile .']
+  secretEnv: ['DOCKERHUB_USERNAME']
+
+- name: 'gcr.io/cloud-builders/docker'
+  waitFor: [
+    'dockerhub-login',
+    'deploy-scripts-build',
   ]
+  # bash entrypoint is required in order to pass the secret environment variables
+  entrypoint: 'bash'
+  # NOTE: The `images` list below is a built in push to GCR. We need to manually push to DockerHub.
+  args: ['-c', 'docker push $$DOCKERHUB_USERNAME/pubsub-emulator:$COMMIT_SHA']
+  secretEnv: ['DOCKERHUB_USERNAME']
+
+availableSecrets:
+  secretManager:
+  # These cloudbuild secrets are managed with atc with config https://github.com/duffelhq/terraform/blob/main/.atc/config-cloudbuild.yaml
+  - versionName: projects/duffel-shared/secrets/cloudbuild-dockerhub-READ_WRITE_TOKEN/versions/1
+    env: 'DOCKERHUB_PASSWORD'
+  - versionName: projects/duffel-shared/secrets/cloudbuild-dockerhub-USERNAME/versions/1
+    env: 'DOCKERHUB_USERNAME'
 
 images: [
   'gcr.io/$PROJECT_ID/pubsub-emulator:$COMMIT_SHA'


### PR DESCRIPTION
As part of cost-saving work for Foundations Q4O2, we are moving some images, those that are frequently pulled by CircleCI pipelines, from Google Container Registry (GCR) to Dockerhub.

With GCR, we have to pay egress costs each time an image is pulled outside GCP's network. With Dockerhub, we're already paying for a pro account (for unlimited pulls from public repositories), and it also allows unlimited pulls from private repositories.

We'll continue pushing to GCR as well as the storage costs are low.

**Successful build**: https://console.cloud.google.com/cloud-build/builds;region=global/e0d8b17c-48e7-4c4b-9728-b2938f17d1bf?project=duffel-shared
**Dockerhub Repository**: https://hub.docker.com/repository/docker/duffelbot/pubsub-emulator

See [Q4O2 scoping doc](https://www.notion.so/duffel/Scoping-doc-2021-Q4-O2-Significantly-reduce-and-more-accurately-attribute-spend-c14ce53497474f41b4390c4c36b7d5b7#296192c7321b4ad287003c1c7430fd9d) for details